### PR TITLE
Fix str on Deck instances

### DIFF
--- a/src/pyartifact/deck.py
+++ b/src/pyartifact/deck.py
@@ -87,7 +87,8 @@ class Deck:
         """Returns the latest version of the deck code."""
         return encode_deck(self.deck_contents)
 
-    __str__ = deck_code
+    def __str__(self) -> str:
+        return self.deck_code
 
     def dumps(self) -> str:
         """

--- a/tests/test_pyartifact.py
+++ b/tests/test_pyartifact.py
@@ -47,3 +47,10 @@ def test_shared_name(cards):
     assert isinstance(storm, Hero)
     blade = cards.get('Apotheosis Blade')
     assert isinstance(blade, Item)
+
+
+def test_deck_str(deck_code):
+    # Only v2 deck_codes round trip
+    if deck_code['version'] == 2:
+        deck = Deck.from_code(deck_code['string'])
+        assert str(deck) == deck_code['string']


### PR DESCRIPTION
The attribute __str__ must be a function which returns a string. Because
deck_code was a property calling str on a deck would result in a str not
callable error.